### PR TITLE
Add [build-system] to pyproject.toml.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,3 +13,7 @@ aiohttp = {version = "^3.4",optional = true}
 pytest = "^3.8"
 sphinx = "^1.8"
 sphinxcontrib-fulltoc = "^1.2"
+
+[build-system]
+requires = ["poetry"]
+build-backend = "poetry.masonry.api"


### PR DESCRIPTION
Hey, `pip` doesn't read the values in `pyproject.toml` if the `build-backend` isn't specified, so running `pip install git+...` prints the following.

    Successfully installed UNKNOWN-0.0.0

I added a `[build-system]` section which makes the repo pip installable.